### PR TITLE
First Code Review of the New Neon Server

### DIFF
--- a/esadapter/src/main/java/com/ncc/neon/server/services/adapter/es/ElasticSearchAdapter.java
+++ b/esadapter/src/main/java/com/ncc/neon/server/services/adapter/es/ElasticSearchAdapter.java
@@ -1,0 +1,154 @@
+package com.ncc.neon.server.services.adapter.es;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import com.ncc.neon.server.models.query.Query;
+import com.ncc.neon.server.models.query.QueryOptions;
+import com.ncc.neon.server.models.query.result.FieldTypePair;
+import com.ncc.neon.server.models.query.result.TabularQueryResult;
+import com.ncc.neon.server.services.adapters.QueryAdapter;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
+
+/**
+ * ElasticSearchAdapter
+ */
+public class ElasticSearchAdapter implements QueryAdapter {
+    RestHighLevelClient client;
+
+    public ElasticSearchAdapter(String host) {
+        this.client = new RestHighLevelClient(RestClient.builder(new HttpHost(host, 9200)));
+    }
+
+    @Override
+    public Mono<TabularQueryResult> execute(Query query, QueryOptions options) {
+        return null;
+    }
+
+    // TODO: generalize getting flux further?
+    @Override
+    public Flux<String> showDatabases() {
+        GetIndexRequest request = new GetIndexRequest().indices("*");
+        return Flux.create(sink -> {
+            client.indices().getAsync(request, RequestOptions.DEFAULT, new ActionListener<GetIndexResponse>() {
+                @Override
+                public void onResponse(GetIndexResponse response) {
+                    String[] indices = response.getIndices();
+                    for (String index : indices) {
+                        sink.next(index);
+                    }
+                    sink.complete();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    sink.error(e);
+                }
+            });
+        });
+
+    }
+
+    @Override
+    public Flux<String> showTables(String dbName) {
+        GetMappingsRequest request = new GetMappingsRequest();
+        request.indices(dbName);
+
+        return getMappingRequestToFlux(request, (sink, response) -> {
+            response.getMappings().get(dbName).keysIt().forEachRemaining(type -> sink.next(type));
+        });
+
+    }
+
+    @Override
+    public Flux<String> getFieldNames(String dbName, String tableName) {
+        BiConsumer<FluxSink<String>, Map<String, Map>> mappingConsumer = (sink, mappingProperties) -> {
+            getMappingProperties(mappingProperties, null).forEach(pair -> sink.next(pair.getField()));
+        };
+        return getMappings(dbName, tableName, mappingConsumer);
+
+    }
+
+    @Override
+    public Flux<FieldTypePair> getFieldTypes(String dbName, String tableName) {
+        BiConsumer<FluxSink<FieldTypePair>, Map<String, Map>> mappingConsumer = (sink, mappingProperties) -> {
+            getMappingProperties(mappingProperties, null).forEach(pair -> sink.next(pair));
+        };
+        return getMappings(dbName, tableName, mappingConsumer);
+    }
+
+    /*
+     * Helper function for getfieldname and getfieldtypes as they are the same
+     */
+    private <T> Flux<T> getMappings(String dbName, String tableName,
+            BiConsumer<FluxSink<T>, Map<String, Map>> mappingConsumer) {
+        GetMappingsRequest request = new GetMappingsRequest();
+        request.indices(dbName);
+        request.types(tableName);
+
+        return getMappingRequestToFlux(request, (sink, response) -> {
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            Map<String, Map> mappingProperties = (Map<String, Map>) response.mappings().get(dbName).get(tableName)
+                    .sourceAsMap().get("properties");
+
+            mappingConsumer.accept(sink, mappingProperties);
+        });
+    }
+
+    /* Recursive function to get all the properties */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private List<FieldTypePair> getMappingProperties(Map<String, Map> mappingProperties, String parentFieldName) {
+        List<FieldTypePair> fieldTypePairs = new ArrayList<>();
+        mappingProperties.forEach((fieldName, value) -> {
+            String type = null;
+            if (value.get("type") != null) {
+                type = value.get("type").toString();
+                if (parentFieldName != null) {
+                    fieldName = parentFieldName + "." + fieldName;
+                }
+                fieldTypePairs.add(new FieldTypePair(fieldName, type));
+            } else if (value.get("properties") != null) {
+                Map<String, Map> subMapping = (Map<String, Map>) value.get("properties");
+                fieldTypePairs.addAll(getMappingProperties(subMapping, fieldName));
+            }
+        });
+        return fieldTypePairs;
+    }
+
+    /* Every method need to convert into a flux */
+    private <T> Flux<T> getMappingRequestToFlux(GetMappingsRequest request,
+            BiConsumer<FluxSink<T>, GetMappingsResponse> responseHandler) {
+        return Flux.create(sink -> {
+            client.indices().getMappingAsync(request, RequestOptions.DEFAULT,
+                    new ActionListener<GetMappingsResponse>() {
+
+                        @Override
+                        public void onResponse(GetMappingsResponse response) {
+                            responseHandler.accept(sink, response);
+                            sink.complete();
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            sink.error(e);
+                        }
+                    });
+        });
+    }
+
+}

--- a/esadapter/src/main/java/com/ncc/neon/server/services/adapter/es/ElasticSearchAdapterFactory.java
+++ b/esadapter/src/main/java/com/ncc/neon/server/services/adapter/es/ElasticSearchAdapterFactory.java
@@ -1,0 +1,27 @@
+package com.ncc.neon.server.services.adapter.es;
+
+import com.ncc.neon.server.models.connection.ConnectionInfo;
+import com.ncc.neon.server.services.adapters.QueryAdapter;
+import com.ncc.neon.server.services.adapters.QueryAdapterFactory;
+
+import org.springframework.stereotype.Component;
+
+//import org.springframework.stereotype.Component;
+
+/**
+ * ElasticSearchAdapterFactory
+ */
+@Component
+public class ElasticSearchAdapterFactory implements QueryAdapterFactory {
+
+    @Override
+    public String getName() {
+        return "elasticsearchrest1";
+    }
+
+    @Override
+    public QueryAdapter initialize(ConnectionInfo cInfo) {
+        return new ElasticSearchAdapter(cInfo.getHost());
+    }
+
+}

--- a/server/src/main/java/com/ncc/neon/server/controllers/QueryController.java
+++ b/server/src/main/java/com/ncc/neon/server/controllers/QueryController.java
@@ -1,0 +1,155 @@
+package com.ncc.neon.server.controllers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.ncc.neon.server.models.connection.ConnectionInfo;
+import com.ncc.neon.server.models.query.Query;
+import com.ncc.neon.server.models.query.QueryOptions;
+import com.ncc.neon.server.models.query.result.TabularQueryResult;
+import com.ncc.neon.server.services.QueryService;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Service for executing queries against an arbitrary data store.
+ */
+@RestController
+@RequestMapping("queryservice")
+public class QueryController {
+
+    private QueryService queryService;
+
+    QueryController(QueryService queryService) {
+        this.queryService = queryService;
+    }
+
+    /**
+     * Executes a query against the supplied connection. This takes into account the
+     * user's current filters so the results will be limited by these if they exist.
+     * 
+     * @param host             The host the database is running on
+     * @param databaseType     the type of database
+     * @param includeFilters   If filters should be ignored and all data should be
+     *                         returned. Defaults to false.
+     * @param selectionOnly    If only data that is currently selected should be
+     *                         returned. Defaults to false.
+     * @param ignoredFilterIds If any specific filters should be ignored (only used
+     *                         if includeFilters is false)
+     * @param query            The query being executed
+     * @return The result of the query
+     */
+    @PostMapping(path = "query/{host}/{databaseType}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE, consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
+   // @ResponseBody
+    Mono<TabularQueryResult> executeQuery(@PathVariable String host, @PathVariable String databaseType,
+            @RequestParam(value = "ignoreFilters", defaultValue = "false") boolean ignoreFilters,
+            @RequestParam(value = "selectionOnly", defaultValue = "false") boolean selectionOnly,
+            @RequestParam(value = "ignoreFilterIds", defaultValue = "false") Set<String> ignoreFilterIds,
+            @RequestBody Query query) {
+        ConnectionInfo ci = new ConnectionInfo(databaseType, host);
+        QueryOptions options = new QueryOptions(ignoreFilters, selectionOnly, null, ignoreFilterIds);
+        return queryService.executeQuery(ci, query, options);
+    }
+
+    /**
+     * Gets a list of all the databases for the database type/host pair.
+     * 
+     * @param host         The host the database is running on
+     * @param databaseType the type of database
+     * @return The list of database names
+     */
+    @GetMapping(path = "databasenames/{host}/{databaseType}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    Mono<List<String>> getDatabaseNames(@PathVariable String host, @PathVariable String databaseType) {
+        ConnectionInfo ci = new ConnectionInfo(databaseType, host);
+        return queryService.getDatabaseNames(ci).collectList();
+    }
+
+    /**
+     * Get all the column's types for tabular datasets from the supplied connection.
+     * 
+     * @param host         The host the database is running on
+     * @param databaseType the type of database
+     * @param databaseName The database containing the data
+     * @param tableName    The table containing the data
+     * @return The field names and their types.
+     */
+
+    @GetMapping(path = "tablenames/{host}/{databaseType}/{databaseName}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    Mono<List<String>> getTableNames(@PathVariable String host, @PathVariable String databaseType,
+            @PathVariable String databaseName) {
+        ConnectionInfo ci = new ConnectionInfo(databaseType, host);
+        return queryService.getTableNames(ci, databaseName).collectList();
+    }
+
+    /**
+     * Get all the columns for tabular datasets from the supplied connection.
+     * 
+     * @param host         The host the database is running on
+     * @param databaseType the type of database
+     * @param databaseName The database containing the data
+     * @param tableName    The table containing the data
+     * @return The result of the query
+     */
+
+    @GetMapping(path = "fields/{host}/{databaseType}/{databaseName}/{tableName}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    Mono<List<String>> getFields(@PathVariable String host, @PathVariable String databaseType,
+            @PathVariable String databaseName, @PathVariable String tableName) {
+        ConnectionInfo ci = new ConnectionInfo(databaseType, host);
+        return queryService.getFields(ci, databaseName, tableName).collectList();
+    }
+
+    /**
+     * Gets a list of all the tables for the supplied connection
+     * 
+     * @param host         The host the database is running on
+     * @param databaseType the type of database
+     * @param database     The database that contains the tables
+     * @return The list of table names
+     */
+    @GetMapping(path = "fields/types/{host}/{databaseType}/{databaseName}/{tableName}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    Mono<Map<String, String>> getFieldTypes(@PathVariable String host, @PathVariable String databaseType,
+            @PathVariable String databaseName, @PathVariable String tableName) {
+        ConnectionInfo ci = new ConnectionInfo(databaseType, host);
+        return queryService.getFieldTypes(ci, databaseName, tableName).collectMap(p -> p.getField(), p -> p.getType());
+    }
+
+    /**
+     * Get all the columns for all the tables from the supplied connection.
+     * 
+     * @param host         The host the database is running on
+     * @param databaseType the type of database
+     * @param databaseName The database containing the data
+     * @return
+     * @return The result of the query
+     */
+    // Spring WebFlux can only deal with one reactive type and won't deal with
+    // nested reactive types (like a Mono<Flux<Integer>>
+    @GetMapping(path = "tablesandfields/{host}/{databaseType}/{databaseName}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    Mono<Map<String, List<String>>> getTablesAndFields(@PathVariable String host, @PathVariable String databaseType,
+            @PathVariable String databaseName) {
+        ConnectionInfo ci = new ConnectionInfo(databaseType, host);
+        Flux<String> tableNames = this.queryService.getTableNames(ci, databaseName);
+
+        return tableNames.collect(Collectors.toMap(tableName -> tableName, tableName -> {
+            Flux<String> fields = this.queryService.getFields(ci, databaseName, tableName);
+            ArrayList<String> fieldList = new ArrayList<>();
+            fields.collectList().subscribe(f -> {
+                fieldList.addAll(f);
+            });
+            return fieldList;
+        }));
+    }
+}

--- a/server/src/main/java/com/ncc/neon/server/models/query/Query.java
+++ b/server/src/main/java/com/ncc/neon/server/models/query/Query.java
@@ -1,0 +1,40 @@
+package com.ncc.neon.server.models.query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ncc.neon.server.models.query.clauses.AggregateClause;
+import com.ncc.neon.server.models.query.clauses.GroupByClause;
+import com.ncc.neon.server.models.query.clauses.LimitClause;
+import com.ncc.neon.server.models.query.clauses.OffsetClause;
+import com.ncc.neon.server.models.query.clauses.SelectClause;
+import com.ncc.neon.server.models.query.clauses.SortClause;
+import com.ncc.neon.server.models.query.filter.Filter;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Query
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+// @JsonIgnoreProperties(value = {"ignoreFilters_", "selectionOnly_",
+// "ignoredFilterIds_"})
+public class Query {
+    Filter filter;
+    boolean aggregateArraysByElement = false;
+
+    @JsonProperty(value = "isDistinct")
+    boolean isDistinct = false;
+
+    List<String> fields = SelectClause.ALL_FIELDS;
+    List<AggregateClause> aggregates = new ArrayList<>();
+    List<GroupByClause> groupByClauses = new ArrayList<>();
+    List<SortClause> sortClauses = new ArrayList<>();
+    LimitClause limitClause;
+    OffsetClause offsetClause;
+}

--- a/server/src/main/java/com/ncc/neon/server/services/QueryAdapterLocator.java
+++ b/server/src/main/java/com/ncc/neon/server/services/QueryAdapterLocator.java
@@ -1,0 +1,50 @@
+package com.ncc.neon.server.services;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.ncc.neon.server.models.connection.ConnectionInfo;
+import com.ncc.neon.server.services.adapters.QueryAdapter;
+import com.ncc.neon.server.services.adapters.QueryAdapterFactory;
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * QueryExecutorLocator
+ */
+@Component
+@Slf4j
+public class QueryAdapterLocator {
+
+    private final Map<String, QueryAdapterFactory> initialContext = new HashMap<>();
+    private final Map<ConnectionInfo, QueryAdapter> cache = new HashMap<>();
+
+    QueryAdapterLocator(List<QueryAdapterFactory> queryAdapterFactories) throws Exception {
+        if (queryAdapterFactories.size() == 0) {
+            log.error("Must have at least one factory");
+            throw new Exception("Must have at least one factory");
+        }
+
+        for (QueryAdapterFactory queryAdapterFactory : queryAdapterFactories) {
+            log.error(queryAdapterFactory.getName());
+            initialContext.put(queryAdapterFactory.getName(), queryAdapterFactory);
+        }
+    }
+
+    QueryAdapter getAdapter(ConnectionInfo ci) {
+
+        QueryAdapter adapter = cache.get(ci);
+
+        if (adapter != null) {
+            return adapter;
+        }
+
+        QueryAdapterFactory adapterFactory = initialContext.get(ci.getDatabaseType());
+        adapter = adapterFactory.initialize(ci);
+        cache.put(ci, adapter);
+        return adapter;
+    }
+}

--- a/server/src/main/java/com/ncc/neon/server/services/QueryService.java
+++ b/server/src/main/java/com/ncc/neon/server/services/QueryService.java
@@ -1,0 +1,51 @@
+package com.ncc.neon.server.services;
+
+import com.ncc.neon.server.models.connection.ConnectionInfo;
+import com.ncc.neon.server.models.query.Query;
+import com.ncc.neon.server.models.query.QueryOptions;
+import com.ncc.neon.server.models.query.result.FieldTypePair;
+import com.ncc.neon.server.models.query.result.TabularQueryResult;
+import com.ncc.neon.server.services.adapters.QueryAdapter;
+
+import org.springframework.stereotype.Component;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * QueryService
+ */
+@Component
+public class QueryService {
+
+    private QueryAdapterLocator queryAdapterLocator;
+
+    QueryService(QueryAdapterLocator queryExecutorLocator) {
+        this.queryAdapterLocator = queryExecutorLocator;
+    }
+
+    public Mono<TabularQueryResult> executeQuery(ConnectionInfo ci, Query query, QueryOptions options) {
+        QueryAdapter adapter = this.queryAdapterLocator.getAdapter(ci);
+        return adapter.execute(query, options);
+    }
+
+    public Flux<String> getDatabaseNames(ConnectionInfo ci) {
+        QueryAdapter adapter = this.queryAdapterLocator.getAdapter(ci);
+        return adapter.showDatabases();
+    }
+
+    public Flux<String> getTableNames(ConnectionInfo ci, String databaseName) {
+        QueryAdapter adapter = this.queryAdapterLocator.getAdapter(ci);
+        return adapter.showTables(databaseName);
+    }
+
+    public Flux<FieldTypePair> getFieldTypes(ConnectionInfo ci, String databaseName, String tableName) {
+        QueryAdapter adapter = this.queryAdapterLocator.getAdapter(ci);
+        return adapter.getFieldTypes(databaseName, tableName);
+    }
+
+    public Flux<String> getFields(ConnectionInfo ci, String databaseName, String tableName) {
+        QueryAdapter adapter = this.queryAdapterLocator.getAdapter(ci);
+        return adapter.getFieldNames(databaseName, tableName);
+    }
+}

--- a/server/src/main/java/com/ncc/neon/server/services/adapters/QueryAdapter.java
+++ b/server/src/main/java/com/ncc/neon/server/services/adapters/QueryAdapter.java
@@ -1,0 +1,56 @@
+package com.ncc.neon.server.services.adapters;
+
+import com.ncc.neon.server.models.query.Query;
+import com.ncc.neon.server.models.query.QueryOptions;
+import com.ncc.neon.server.models.query.result.FieldTypePair;
+import com.ncc.neon.server.models.query.result.TabularQueryResult;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * QueryAdapter - Executes a query against a generic data source
+ */
+
+public interface QueryAdapter {
+
+    /**
+     * Executes a query against a generic data source given the current filter and
+     * selection state.
+     * 
+     * @param query   An object that represents the query we wish to execute
+     * @param options Determines if we should include filters or selection in the
+     *                query execution
+     * @return An object containing the results of the query
+     */
+    Mono<TabularQueryResult> execute(Query query, QueryOptions options);
+
+    /**
+     * @return Returns all the databases
+     */
+    Flux<String> showDatabases();
+
+    /**
+     * @param dbName The current database
+     * @return Returns all the table names within the current database
+     */
+    Flux<String> showTables(String dbName);
+
+    /**
+     * Gets the names of the fields in the specified dataset
+     * 
+     * @param databaseName
+     * @param tableName
+     * @return
+     */
+    Flux<String> getFieldNames(String databaseName, String tableName);
+
+    /**
+     * Gets the types of the fields in the specified dataset
+     * 
+     * @param databaseName
+     * @param tableName
+     * @return Mapping of field name to field type
+     */
+    Flux<FieldTypePair> getFieldTypes(String databaseName, String tableName);
+}

--- a/server/src/main/java/com/ncc/neon/server/services/adapters/QueryAdapterFactory.java
+++ b/server/src/main/java/com/ncc/neon/server/services/adapters/QueryAdapterFactory.java
@@ -1,0 +1,21 @@
+package com.ncc.neon.server.services.adapters;
+
+import com.ncc.neon.server.models.connection.ConnectionInfo;
+
+/**
+ * QueryAdapterFactory
+ */
+public interface QueryAdapterFactory {
+
+    /**
+     * Gets the name of the fiendly name of the adapter.
+     */
+    String getName();
+
+    /**
+     * Responsable to for connecting to the datastore
+     * 
+     * @param cInfo {@link ConnectionInfo} used to connect to the data store
+     */
+    QueryAdapter initialize(ConnectionInfo cInfo);
+}

--- a/server/src/main/java/com/ncc/neon/server/services/adapters/dummy/DummyQueryAdapter.java
+++ b/server/src/main/java/com/ncc/neon/server/services/adapters/dummy/DummyQueryAdapter.java
@@ -1,0 +1,54 @@
+package com.ncc.neon.server.services.adapters.dummy;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.ncc.neon.server.models.query.Query;
+import com.ncc.neon.server.models.query.QueryOptions;
+import com.ncc.neon.server.models.query.result.FieldTypePair;
+import com.ncc.neon.server.models.query.result.TabularQueryResult;
+import com.ncc.neon.server.services.adapters.QueryAdapter;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * DummyQueryAdapter
+ */
+public class DummyQueryAdapter implements QueryAdapter {
+
+    @Override
+    public Mono<TabularQueryResult> execute(Query query, QueryOptions options) {
+        List<Map<String, Object>> table = new ArrayList<>();
+        Map<String, Object> row = new HashMap<>();
+        row.put("column1", "value1");
+        row.put("column2", 2);
+        table.add(row);
+        table.add(row);
+        return Mono.just(new TabularQueryResult(table));
+    }
+
+    @Override
+    public Flux<String> showDatabases() {
+        return Flux.just("A", "B", "C", "X", "Y", "Z");
+    }
+
+    @Override
+    public Flux<String> showTables(String dbName) {
+        return Flux.just("1", "2");
+    }
+
+    @Override
+    public Flux<String> getFieldNames(String databaseName, String tableName) {
+        return Flux.just("id", "date", "msg");
+    }
+
+    @Override
+    public Flux<FieldTypePair> getFieldTypes(String databaseName, String tableName) {
+        Flux<FieldTypePair> fieldTypes = getFieldNames("", "").map(name -> new FieldTypePair(name, name + "-type"));
+        return fieldTypes;
+    }
+
+}

--- a/server/src/main/java/com/ncc/neon/server/services/adapters/dummy/DummyQueryAdapterFactory.java
+++ b/server/src/main/java/com/ncc/neon/server/services/adapters/dummy/DummyQueryAdapterFactory.java
@@ -1,0 +1,25 @@
+package com.ncc.neon.server.services.adapters.dummy;
+
+import com.ncc.neon.server.models.connection.ConnectionInfo;
+import com.ncc.neon.server.services.adapters.QueryAdapter;
+import com.ncc.neon.server.services.adapters.QueryAdapterFactory;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * DummyQueryAdapterFactory
+ */
+@Component
+public class DummyQueryAdapterFactory implements QueryAdapterFactory {
+
+    @Override
+    public String getName() {
+        return "dummy";
+    }
+
+    @Override
+    public QueryAdapter initialize(ConnectionInfo cInfo) {
+        return new DummyQueryAdapter();
+    }
+
+}


### PR DESCRIPTION
We've picked the 10 most important files for you all to review.  Here's how it works:

- The `QueryController` defines the REST endpoints and sends `Query` objects to the `QueryService`.
- The `QueryService` sends `Query` objects to the `QueryAdapter` matching the given `ConnectionInfo` (datastore type, hostname, and port) and returns the `QueryResults` to the `QueryController`.
- The `QueryAdapterLocator` creates new `QueryAdapter` objects and saves them for continued use.
- The `QueryAdapterFactory` and `QueryAdapter` are interfaces implemented by each type of datastore:  the `QueryAdapterFactory` creates the datastore connection; the `QueryAdapter` transforms the `Query` objects into datastore-language queries, runs them, and transforms the results into `QueryResult` objects.

The ES adapter still needs to be finished, and there's still cleanup to be done, but we wanted to familiarize you with the basic architecture and workflow.  Notice that the REST server code is kept in the `server` top-level folder while the adapters will each have their own top-level folder (the ES adapter is in `esadapter`) to enable modularity (choosing which adapters you want to include in the pacakge that is built).

Please let us know if you have any questions!