### PR TITLE
bug fix: use library available on java 8 and above

### DIFF
--- a/server/src/main/java/com/ncc/neon/controllers/ExportController.java
+++ b/server/src/main/java/com/ncc/neon/controllers/ExportController.java
@@ -42,7 +42,8 @@ public class ExportController {
 
     private String[] GetCSVHeader(List<FieldNamePrettyNamePair> fieldNamePrettyNamePairs)
     {
-        return fieldNamePrettyNamePairs.stream().map(pair -> pair.getPretty()).collect(Collectors.toList()).toArray(String[]::new);
+        List<String> fieldNamePrettyNameList = fieldNamePrettyNamePairs.stream().map(pair -> pair.getPretty()).collect(Collectors.toList());
+        return fieldNamePrettyNameList.stream().toArray(String[]::new);
     }
 
     private String[] GetCSVRecord(Map<String, Object> map, List<FieldNamePrettyNamePair> fieldNamePrettyNamePairs)


### PR DESCRIPTION
toArray method on a list interface is only available on recent version of java and not java 8. using a method avaialbe on java 8 and above. discovered this bug when testing the dashboard in a docker container with java 8 runtime.