### PR TITLE
Bet 68 score view refactor

### DIFF
--- a/server/src/main/java/com/ncc/neon/controllers/BetterController.java
+++ b/server/src/main/java/com/ncc/neon/controllers/BetterController.java
@@ -3,6 +3,7 @@ package com.ncc.neon.controllers;
 import com.ncc.neon.exception.UpsertException;
 import com.ncc.neon.models.BetterFile;
 import com.ncc.neon.models.FileStatus;
+import com.ncc.neon.models.Score;
 import com.ncc.neon.services.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
@@ -30,17 +31,20 @@ public class BetterController {
     private BetterFileService betterFileService;
     private ModuleService moduleService;
     private AsyncService asyncService;
+    private EvaluationService evaluationService;
 
     BetterController(DatasetService datasetService,
                      FileShareService fileShareService,
                      BetterFileService betterFileService,
                      ModuleService moduleService,
-                     AsyncService asyncService) {
+                     AsyncService asyncService,
+                     EvaluationService evaluationService) {
         this.datasetService = datasetService;
         this.fileShareService = fileShareService;
         this.betterFileService = betterFileService;
         this.moduleService = moduleService;
         this.asyncService = asyncService;
+        this.evaluationService = evaluationService;
     }
 
     @GetMapping(path = "status")
@@ -152,5 +156,10 @@ public class BetterController {
                 .subscribe();
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(path="score")
+    Mono<Score> score(@RequestParam("runId") String evalId) {
+        return evaluationService.getOverallScore(evalId);
     }
 }

--- a/server/src/main/java/com/ncc/neon/controllers/BetterController.java
+++ b/server/src/main/java/com/ncc/neon/controllers/BetterController.java
@@ -157,9 +157,4 @@ public class BetterController {
 
         return ResponseEntity.ok().build();
     }
-
-    @GetMapping(path="score")
-    Mono<?> score(@RequestParam("runId") String runId) {
-        return evaluationService.getOverallScoreByRunId(runId);
-    }
 }

--- a/server/src/main/java/com/ncc/neon/controllers/BetterController.java
+++ b/server/src/main/java/com/ncc/neon/controllers/BetterController.java
@@ -159,7 +159,7 @@ public class BetterController {
     }
 
     @GetMapping(path="score")
-    Mono<Score> score(@RequestParam("runId") String evalId) {
-        return evaluationService.getOverallScore(evalId);
+    Mono<?> score(@RequestParam("runId") String runId) {
+        return evaluationService.getOverallScoreByRunId(runId);
     }
 }

--- a/server/src/main/java/com/ncc/neon/models/EvaluationResponse.java
+++ b/server/src/main/java/com/ncc/neon/models/EvaluationResponse.java
@@ -7,7 +7,7 @@ public class EvaluationResponse {
     private final Score[] evaluation;
     private final BetterFile[] files;
 
-    public double getOverallScore() {
-        return evaluation[evaluation.length - 1].getCombinedScore();
+    public Score getOverallScore() {
+        return evaluation[evaluation.length - 1];
     }
 }

--- a/server/src/main/java/com/ncc/neon/models/Score.java
+++ b/server/src/main/java/com/ncc/neon/models/Score.java
@@ -29,6 +29,8 @@ public class Score {
     private double argMatches;
     @JsonProperty("arg-precision")
     private double argPrecision;
+    @JsonProperty("arg-recall")
+    private double argRecall;
     @JsonProperty("arg-fmeasure")
     private double argFmeasure;
     @JsonProperty("combined-score")

--- a/server/src/main/java/com/ncc/neon/services/ElasticSearchService.java
+++ b/server/src/main/java/com/ncc/neon/services/ElasticSearchService.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import java.util.Map;
 
 public abstract class ElasticSearchService<T> {
-    private final RestHighLevelClient elasticSearchClient;
+    protected final RestHighLevelClient elasticSearchClient;
     private final String index;
     private final String dataType;
     private final Class<T> type;

--- a/server/src/main/java/com/ncc/neon/services/EvaluationService.java
+++ b/server/src/main/java/com/ncc/neon/services/EvaluationService.java
@@ -1,9 +1,11 @@
 package com.ncc.neon.services;
 
 import com.ncc.neon.models.EvaluationOutput;
+import com.ncc.neon.models.Score;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 
 @Component
 public class EvaluationService extends ElasticSearchService<EvaluationOutput> {
@@ -12,5 +14,11 @@ public class EvaluationService extends ElasticSearchService<EvaluationOutput> {
                       @Value("${db_host}") String dbHost,
                       @Value("${evaluation.table}") String evalTable) {
         super(dbHost, evalTable, evalTable, EvaluationOutput.class, datasetService);
+    }
+
+    public Mono<Score> getOverallScore(String evalId) {
+        // The overall score is the last score in the evaluation.
+        return getById(evalId)
+                .map(eval -> eval.getScore()[eval.getScore().length - 1]);
     }
 }

--- a/server/src/main/java/com/ncc/neon/services/EvaluationService.java
+++ b/server/src/main/java/com/ncc/neon/services/EvaluationService.java
@@ -1,11 +1,22 @@
 package com.ncc.neon.services;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ncc.neon.models.EvaluationOutput;
 import com.ncc.neon.models.Score;
+import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.util.ArrayList;
 
 @Component
 public class EvaluationService extends ElasticSearchService<EvaluationOutput> {
@@ -16,9 +27,27 @@ public class EvaluationService extends ElasticSearchService<EvaluationOutput> {
         super(dbHost, evalTable, evalTable, EvaluationOutput.class, datasetService);
     }
 
-    public Mono<Score> getOverallScore(String evalId) {
-        // The overall score is the last score in the evaluation.
-        return getById(evalId)
-                .map(eval -> eval.getScore()[eval.getScore().length - 1]);
+    public Mono<?> getOverallScoreByRunId(String runId) {
+        SearchRequest searchRequest = new SearchRequest("evaluation");
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+
+        QueryBuilder queryBuilder = QueryBuilders
+                .matchQuery("runID", runId);
+
+        searchSourceBuilder.query(queryBuilder);
+
+        return Mono.create(sink -> {
+           searchRequest.source(searchSourceBuilder);
+            try {
+                SearchResponse response = elasticSearchClient.search(searchRequest, RequestOptions.DEFAULT);
+
+                ObjectMapper objectMapper = new ObjectMapper();
+                EvaluationOutput evaluationOutput = objectMapper.convertValue(response.getHits().getAt(0).getSourceAsMap(), EvaluationOutput.class);
+
+                sink.success(evaluationOutput.getScore()[evaluationOutput.getScore().length - 1]);
+            } catch (IOException e) {
+                sink.error(e);
+            }
+        });
     }
 }

--- a/server/src/main/java/com/ncc/neon/services/RunService.java
+++ b/server/src/main/java/com/ncc/neon/services/RunService.java
@@ -1,7 +1,9 @@
 package com.ncc.neon.services;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ncc.neon.models.Run;
 import com.ncc.neon.models.RunStatus;
+import com.ncc.neon.models.Score;
 import com.ncc.neon.util.DateUtil;
 import org.elasticsearch.rest.RestStatus;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +24,8 @@ public class RunService extends ElasticSearchService<Run> {
     private static final String STATUS_FIELD = "status";
     private static final String STATUS_MESSAGE_FIELD = "status_message";
     private static final String OVERALL_SCORE_FIELD = "overall_score";
+
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Autowired
     RunService(DatasetService datasetService,
@@ -62,10 +66,11 @@ public class RunService extends ElasticSearchService<Run> {
         return updateAndRefresh(data, runId);
     }
 
-    public Mono<RestStatus> updateToDoneStatus(String completedRunId, double overallScore) {
+    public Mono<RestStatus> updateToDoneStatus(String completedRunId, Score overallScore) {
         Map<String, Object> data = new HashMap<>();
+        Map<String, Object> scoreData = mapper.convertValue(overallScore, Map.class);
         data.put(STATUS_FIELD, RunStatus.DONE);
-        data.put(OVERALL_SCORE_FIELD, overallScore);
+        data.put(OVERALL_SCORE_FIELD, scoreData);
         return updateAndRefresh(data, completedRunId);
     }
 


### PR DESCRIPTION
This patch refactors the Evaluation model to take the entire overall score entry as the overall score, instead of just the combined score metric.  The reason for this is to not put the burden on the client to fetch the overall score for an evaluation.