### PR TITLE
NEON 59 - transform millis to date

### DIFF
--- a/common/src/main/java/com/ncc/neon/util/DateUtil.java
+++ b/common/src/main/java/com/ncc/neon/util/DateUtil.java
@@ -1,6 +1,8 @@
 package com.ncc.neon.util;
 
 import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -21,6 +23,15 @@ public class DateUtil {
             return DateTimeFormatter.ISO_DATE_TIME.format(date);
         }
         catch(DateTimeException e1) {
+            return null;
+        }
+    }
+
+    public static ZonedDateTime transformMillisecondsToDate(Long dateLong) {
+        try {
+            return ZonedDateTime.ofInstant(Instant.ofEpochMilli(dateLong), ZoneId.of("UTC"));
+        }
+        catch (DateTimeException e) {
             return null;
         }
     }

--- a/server/src/test/java/com/ncc/neon/util/DateUtilTest.java
+++ b/server/src/test/java/com/ncc/neon/util/DateUtilTest.java
@@ -66,4 +66,10 @@ public class DateUtilTest {
         ZonedDateTime date = DateUtil.transformStringToDate("2019-01-01T00:00:30.500Z");
         assertThat(date.toString()).isEqualTo("2019-01-01T00:00:30.500Z");
     }
+
+    @Test
+    public void transformMillisecondsToDateTest() {
+        ZonedDateTime date = DateUtil.transformMillisecondsToDate(1546300830500L);
+        assertThat(date.toString()).isEqualTo("2019-01-01T00:00:30.500Z[UTC]");
+    }
 }


### PR DESCRIPTION
Fixes: [NEON-59](https://nextcentury.atlassian.net/browse/NEON-59)

Simple millisecond to UTC Zoned Date convert method. Added a test in the DateUtilsTest class.