### PR TITLE
NEON 61 -  Add new data in datastore

### DIFF
--- a/common/src/main/java/com/ncc/neon/adapters/QueryAdapter.java
+++ b/common/src/main/java/com/ncc/neon/adapters/QueryAdapter.java
@@ -120,4 +120,6 @@ public abstract class QueryAdapter {
     public abstract Mono<ActionResult> importData(ImportQuery importQuery);
 
     public abstract Mono<ActionResult> mutateData(MutateQuery mutate);
+
+    public abstract Mono<ActionResult> insertData(MutateQuery mutate);
 }

--- a/common/src/main/java/com/ncc/neon/adapters/dummy/DummyQueryAdapter.java
+++ b/common/src/main/java/com/ncc/neon/adapters/dummy/DummyQueryAdapter.java
@@ -81,4 +81,9 @@ public class DummyQueryAdapter extends QueryAdapter {
     public Mono<ActionResult> mutateData(MutateQuery mutate) {
         return Mono.just(new ActionResult());
     }
+
+    @Override
+    public Mono<ActionResult> insertData(MutateQuery mutate) {
+        return null;
+    }
 }

--- a/common/src/main/java/com/ncc/neon/adapters/dummy/DummyQueryAdapter.java
+++ b/common/src/main/java/com/ncc/neon/adapters/dummy/DummyQueryAdapter.java
@@ -84,6 +84,6 @@ public class DummyQueryAdapter extends QueryAdapter {
 
     @Override
     public Mono<ActionResult> insertData(MutateQuery mutate) {
-        return null;
+        return Mono.just(new ActionResult());
     }
 }

--- a/esadapter/src/main/java/com/ncc/neon/adapters/es/ElasticsearchAdapter.java
+++ b/esadapter/src/main/java/com/ncc/neon/adapters/es/ElasticsearchAdapter.java
@@ -414,4 +414,9 @@ public class ElasticsearchAdapter extends QueryAdapter {
             });
         });
     }
+
+    @Override
+    public Mono<ActionResult> insertData(MutateQuery mutate) {
+        return null;
+    }
 }

--- a/esadapter/src/main/java/com/ncc/neon/adapters/es/ElasticsearchQueryConverter.java
+++ b/esadapter/src/main/java/com/ncc/neon/adapters/es/ElasticsearchQueryConverter.java
@@ -25,6 +25,7 @@ import com.ncc.neon.models.queries.Order;
 import com.ncc.neon.models.queries.WhereClause;
 import com.ncc.neon.util.DateUtil;
 
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -443,5 +444,10 @@ public class ElasticsearchQueryConverter {
     public static UpdateRequest convertMutationByIdQuery(MutateQuery mutateQuery) {
         return new UpdateRequest(mutateQuery.getDatabaseName(), mutateQuery.getTableName(), mutateQuery.getDataId())
             .doc(mutateQuery.getFieldsWithValues());
+    }
+
+    public static IndexRequest convertMutationInsertQuery(MutateQuery mutateQuery) {
+        return new IndexRequest(mutateQuery.getDatabaseName(), mutateQuery.getTableName(), mutateQuery.getDataId())
+                .source(mutateQuery.getFieldsWithValues());
     }
 }

--- a/esadapter/src/test/java/com/ncc/neon/adapters/es/ElasticsearchQueryConverterTest.java
+++ b/esadapter/src/test/java/com/ncc/neon/adapters/es/ElasticsearchQueryConverterTest.java
@@ -13,6 +13,7 @@ import com.ncc.neon.models.queries.Query;
 import com.ncc.neon.models.queries.SelectClause;
 import com.ncc.neon.models.queries.SingularWhereClause;
 
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -1056,6 +1057,26 @@ public class ElasticsearchQueryConverterTest extends QueryBuilder {
         UpdateRequest actual = ElasticsearchQueryConverter.convertMutationByIdQuery(mutateQuery);
         UpdateRequest expected = new UpdateRequest("testDatabase", "testTable", "testId")
             .doc(mutateQuery.getFieldsWithValues());
+        // This test fails without the toString (I don't know why)
+        assertThat(actual.toString()).isEqualTo(expected.toString());
+    }
+
+    @Test
+    public void convertMutationByIdQueryIndexRequestTest() {
+        MutateQuery mutateQuery = buildMutationByIdQuery();
+        IndexRequest actual = ElasticsearchQueryConverter.convertMutationInsertQuery(mutateQuery);
+        IndexRequest expected = new IndexRequest("testDatabase", "testTable", "testId")
+                .source(mutateQuery.getFieldsWithValues());
+        // This test fails without the toString (I don't know why)
+        assertThat(actual.toString()).isEqualTo(expected.toString());
+    }
+
+    @Test
+    public void convertArrayAndObjectMutationByIdQueryIndexRequestTest() {
+        MutateQuery mutateQuery = buildArrayAndObjectMutationByIdQuery();
+        IndexRequest actual = ElasticsearchQueryConverter.convertMutationInsertQuery(mutateQuery);
+        IndexRequest expected = new IndexRequest("testDatabase", "testTable", "testId")
+                .source(mutateQuery.getFieldsWithValues());
         // This test fails without the toString (I don't know why)
         assertThat(actual.toString()).isEqualTo(expected.toString());
     }

--- a/esadapter/src/test/java/com/ncc/neon/adapters/es/ElasticsearchQueryConverterTest.java
+++ b/esadapter/src/test/java/com/ncc/neon/adapters/es/ElasticsearchQueryConverterTest.java
@@ -1062,7 +1062,7 @@ public class ElasticsearchQueryConverterTest extends QueryBuilder {
     }
 
     @Test
-    public void convertMutationByIdQueryIndexRequestTest() {
+    public void convertInsertQueryTest() {
         MutateQuery mutateQuery = buildMutationByIdQuery();
         IndexRequest actual = ElasticsearchQueryConverter.convertMutationInsertQuery(mutateQuery);
         IndexRequest expected = new IndexRequest("testDatabase", "testTable", "testId")
@@ -1072,7 +1072,7 @@ public class ElasticsearchQueryConverterTest extends QueryBuilder {
     }
 
     @Test
-    public void convertArrayAndObjectMutationByIdQueryIndexRequestTest() {
+    public void convertArrayAndObjectInsertQueryTest() {
         MutateQuery mutateQuery = buildArrayAndObjectMutationByIdQuery();
         IndexRequest actual = ElasticsearchQueryConverter.convertMutationInsertQuery(mutateQuery);
         IndexRequest expected = new IndexRequest("testDatabase", "testTable", "testId")

--- a/server/src/main/java/com/ncc/neon/controllers/InsertController.java
+++ b/server/src/main/java/com/ncc/neon/controllers/InsertController.java
@@ -1,0 +1,71 @@
+package com.ncc.neon.controllers;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import com.ncc.neon.models.ConnectionInfo;
+import com.ncc.neon.models.DataNotification;
+import com.ncc.neon.models.queries.MutateQuery;
+import com.ncc.neon.models.results.ActionResult;
+import com.ncc.neon.services.DatasetService;
+import com.ncc.neon.services.QueryService;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Triple;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Mono;
+
+@CrossOrigin(origins = "*")
+@RestController
+@RequestMapping("insertservice")
+public class InsertController {
+    private DatasetService datasetService;
+    private QueryService queryService;
+
+    InsertController(DatasetService datasetService, QueryService queryService) {
+        this.datasetService = datasetService;
+        this.queryService = queryService;
+    }
+
+    @PostMapping(path="/insert", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<Mono<ActionResult>> insertData(@RequestBody MutateQuery mutateQuery) {
+
+        final Predicate<String> isBlank = StringUtils::isBlank;
+        final Predicate<Collection> isEmpty = CollectionUtils::isEmpty;
+
+        Triple[] labeledInput = new Triple[]{
+                Triple.of("Datastore Host", mutateQuery.getDatastoreHost(), isBlank),
+                Triple.of("Datastore Type", mutateQuery.getDatastoreType(), isBlank),
+                Triple.of("Database Name", mutateQuery.getDatabaseName(), isBlank),
+                Triple.of("Table Name", mutateQuery.getTableName(), isBlank),
+                Triple.of("Fields with Values", mutateQuery.getFieldsWithValues().entrySet(), isEmpty),
+        };
+
+        List<String> invalidInput = Arrays.asList(labeledInput).stream()
+                .filter(triple -> ((Predicate)triple.getRight()).test(triple.getMiddle()))
+                .map(triple -> (String)triple.getLeft()).collect(Collectors.toList());
+
+        if (invalidInput.size() > 0) {
+            return ResponseEntity.badRequest().body(Mono.just(new ActionResult("Mutation by ID Query Missing " +
+                    String.join(", ", invalidInput))));
+        }
+
+        ConnectionInfo info = new ConnectionInfo(mutateQuery.getDatastoreType(), mutateQuery.getDatastoreHost());
+
+        datasetService.notify(new DataNotification(mutateQuery.getDatastoreHost(), mutateQuery.getDatastoreType(),
+                mutateQuery.getDatabaseName(), mutateQuery.getTableName(), 1));
+
+        return ResponseEntity.ok().body(queryService.insertData(info, mutateQuery));
+    }
+}

--- a/server/src/main/java/com/ncc/neon/services/QueryService.java
+++ b/server/src/main/java/com/ncc/neon/services/QueryService.java
@@ -74,4 +74,9 @@ public class QueryService {
         QueryAdapter adapter = this.queryAdapterLocator.getAdapter(ci);
         return adapter.mutateData(mutateQuery);
     }
+
+    public Mono<ActionResult> insertData(ConnectionInfo ci, MutateQuery mutateQuery) {
+        QueryAdapter adapter = this.queryAdapterLocator.getAdapter(ci);
+        return adapter.insertData(mutateQuery);
+    }
 }

--- a/server/src/test/java/com/ncc/neon/controllers/InsertControllerTests.java
+++ b/server/src/test/java/com/ncc/neon/controllers/InsertControllerTests.java
@@ -1,0 +1,74 @@
+package com.ncc.neon.controllers;
+
+import com.ncc.neon.NeonServerApplication;
+import com.ncc.neon.models.ConnectionInfo;
+import com.ncc.neon.models.queries.MutateQuery;
+import com.ncc.neon.models.results.ActionResult;
+import com.ncc.neon.services.QueryService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = NeonServerApplication.class)
+@SpringBootTest
+@AutoConfigureWebTestClient
+public class InsertControllerTests {
+
+    @Autowired
+    WebTestClient webTestClient;
+
+    @MockBean
+    private QueryService queryService;
+
+    @Test
+    public void testInsertWithInvalidInput() {
+        MutateQuery mutateQuery = new MutateQuery("", "", "", "", "", "", new LinkedHashMap<String, Object>());
+        webTestClient.post()
+                .uri("/insertservice/insert")
+				.contentType(MediaType.APPLICATION_JSON_UTF8)
+                .body(Mono.just(mutateQuery), MutateQuery.class)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    public void testInsertWithValidInput() {
+        MutateQuery mutateQuery = new MutateQuery("testHost", "testType", "testDatabase", "testTable", "testIdField",
+            "testId", new LinkedHashMap<String, Object>(){{
+                put("testStringField", "testStringValue");
+            }}
+        );
+
+        ActionResult mutateResult = new ActionResult("1 rows updated in testDatabase.testTable");
+
+        ConnectionInfo info = new ConnectionInfo(mutateQuery.getDatastoreType(), mutateQuery.getDatastoreHost());
+
+        when(queryService.insertData(info, mutateQuery)).thenReturn(Mono.just(mutateResult));
+
+        webTestClient.post()
+                .uri("/insertservice/insert")
+                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .body(Mono.just(mutateQuery), MutateQuery.class)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+                .expectBody(ActionResult.class)
+                .value(result -> {
+                    assertEquals(mutateResult, result);
+                });
+    }
+}

--- a/sqladapter/src/main/java/com/ncc/neon/adapters/sql/SqlAdapter.java
+++ b/sqladapter/src/main/java/com/ncc/neon/adapters/sql/SqlAdapter.java
@@ -172,8 +172,11 @@ public class SqlAdapter extends QueryAdapter {
     }
 
     @Override
-    public Mono<ActionResult> insertData(MutateQuery mutate) {
-        return null;
+    public Mono<ActionResult> insertData(MutateQuery mutateQuery) {
+        DatabaseClient database = DatabaseClient.create(this.pool);
+        return database.execute(SqlQueryConverter.convertMutationIntoInsertQuery(mutateQuery)).fetch().rowsUpdated()
+                .map(rowCount -> new ActionResult(rowCount + " rows updated in " + mutateQuery.getDatabaseName() + "." +
+                        mutateQuery.getTableName(), new ArrayList<String>()));
     }
 
     private FieldType retrieveFieldType(String type) {

--- a/sqladapter/src/main/java/com/ncc/neon/adapters/sql/SqlAdapter.java
+++ b/sqladapter/src/main/java/com/ncc/neon/adapters/sql/SqlAdapter.java
@@ -171,6 +171,11 @@ public class SqlAdapter extends QueryAdapter {
                 mutateQuery.getDataId(), new ArrayList<String>()));
     }
 
+    @Override
+    public Mono<ActionResult> insertData(MutateQuery mutate) {
+        return null;
+    }
+
     private FieldType retrieveFieldType(String type) {
         String dataType = type.toLowerCase();
         if (dataType.contains(" ")) {

--- a/sqladapter/src/main/java/com/ncc/neon/adapters/sql/SqlQueryConverter.java
+++ b/sqladapter/src/main/java/com/ncc/neon/adapters/sql/SqlQueryConverter.java
@@ -271,6 +271,15 @@ public class SqlQueryConverter {
         return sqlQueryString;
     }
 
+    public static String convertMutationIntoInsertQuery(MutateQuery mutateQuery) {
+        String sqlQueryString = "INSERT INTO " + mutateQuery.getDatabaseName() + "." + mutateQuery.getTableName() +
+                " (" + String.join(", ", mutateQuery.getFieldsWithValues().keySet()) + ") VALUES (" +
+                mutateQuery.getFieldsWithValues().values().stream().map(value -> SqlQueryConverter
+                        .transformObjectToString(value, false)).collect(Collectors.joining(", ")) + ")";
+
+        return sqlQueryString;
+    }
+
     private static String transformObjectToString(Object object, boolean insideJson) {
         if (object instanceof String) {
             return (insideJson ? "\"" : "'") + object + (insideJson ? "\"" : "'");

--- a/sqladapter/src/test/java/com/ncc/neon/adapters/sql/MySqlQueryConverterTest.java
+++ b/sqladapter/src/test/java/com/ncc/neon/adapters/sql/MySqlQueryConverterTest.java
@@ -732,4 +732,25 @@ public class MySqlQueryConverterTest extends QueryBuilder {
             "\"testObjectArray\":[\"e\",5]}' WHERE testIdField = 'testId'";
         assertThat(actual).isEqualTo(expected);
     }
+
+    @Test
+    public void convertMutationQueryInsertTest() {
+        MutateQuery mutateQuery = buildMutationByIdQuery();
+        String actual = SqlQueryConverter.convertMutationIntoInsertQuery(mutateQuery);
+        String expected = "INSERT INTO testDatabase.testTable (testString, testZero, testInteger, testDecimal, " +
+                "testNegativeInteger, testNegativeDecimal, testTrue, testFalse) VALUES ('a', 0, 1, 0.5, -1, -0.5, " +
+                "true, false)";
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void convertArrayAndObjectMutationQueryInsertTest() {
+        MutateQuery mutateQuery = buildArrayAndObjectMutationByIdQuery();
+        String actual = SqlQueryConverter.convertMutationIntoInsertQuery(mutateQuery);
+        String expected = "INSERT INTO testDatabase.testTable (testEmptyArray, testEmptyObject, testArray, " +
+                "testObject) VALUES ('[]', '{}', '[\"b\",2,true,{\"testArrayObjectString\":\"c\"," +
+                "\"testArrayObjectInteger\":3}]', '{\"testObjectString\":\"d\",\"testObjectInteger\":4," +
+                "\"testObjectBoolean\":true,\"testObjectArray\":[\"e\",5]}')";
+        assertThat(actual).isEqualTo(expected);
+    }
 }

--- a/sqladapter/src/test/java/com/ncc/neon/adapters/sql/PostgreSqlQueryConverterTest.java
+++ b/sqladapter/src/test/java/com/ncc/neon/adapters/sql/PostgreSqlQueryConverterTest.java
@@ -733,4 +733,25 @@ public class PostgreSqlQueryConverterTest extends QueryBuilder {
             "\"testObjectArray\":[\"e\",5]}' WHERE testIdField = 'testId'";
         assertThat(actual).isEqualTo(expected);
     }
+
+    @Test
+    public void convertMutationQueryInsertTest() {
+        MutateQuery mutateQuery = buildMutationByIdQuery();
+        String actual = SqlQueryConverter.convertMutationIntoInsertQuery(mutateQuery);
+        String expected = "INSERT INTO testDatabase.testTable (testString, testZero, testInteger, testDecimal, " +
+                "testNegativeInteger, testNegativeDecimal, testTrue, testFalse) VALUES ('a', 0, 1, 0.5, -1, -0.5, " +
+                "true, false)";
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void convertArrayAndObjectMutationQueryInsertTest() {
+        MutateQuery mutateQuery = buildArrayAndObjectMutationByIdQuery();
+        String actual = SqlQueryConverter.convertMutationIntoInsertQuery(mutateQuery);
+        String expected = "INSERT INTO testDatabase.testTable (testEmptyArray, testEmptyObject, testArray, " +
+                "testObject) VALUES ('[]', '{}', '[\"b\",2,true,{\"testArrayObjectString\":\"c\"," +
+                "\"testArrayObjectInteger\":3}]', '{\"testObjectString\":\"d\",\"testObjectInteger\":4," +
+                "\"testObjectBoolean\":true,\"testObjectArray\":[\"e\",5]}')";
+        assertThat(actual).isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
Added `InsertController` that allows `MutateQuery`'s to be passed in to create data in the datastore. Implemented for MySQL, PostgreSQL, and ElasticSearch.

This was tested using the tests added and from outside calls. Here are the example outside calls used with the earthquakes dataset:

Endpoint (for all datastores): `http://localhost:4200/neon/services/insertservice/insert`

ElasticSearch body:
```
{
  "datastoreHost": "user:password@localhost",
  "datastoreType": "elasticsearch",
  "databaseName": "earthquakes",
  "tableName": "_doc",
  "idFieldName": "testIdField",
  "dataId": "testId",
  "fieldsWithValues": {
    "mag": 1.51,
    "depth": 1.52
  }
}
```

PostgreSQL body:
```
{
  "datastoreHost": "user:password@localhost/earthquakes",
  "datastoreType": "postgresql",
  "databaseName": "earthquakes",
  "tableName": "quakedata",
  "idFieldName": "testIdField",
  "dataId": "testId",
  "fieldsWithValues": {
    "mag": 1.51,
    "depth": 1.52
  }
}
```
To check for ES data: `http://localhost:9200/earthquakes/_search?q=depth:1.52&pretty`
Used pgadmin to check for PostgreSQL data.
