### PR TITLE
NEON 65 - Delete by filter

### DIFF
--- a/common/src/main/java/com/ncc/neon/adapters/QueryBuilder.java
+++ b/common/src/main/java/com/ncc/neon/adapters/QueryBuilder.java
@@ -1,29 +1,11 @@
 package com.ncc.neon.adapters;
 
+import com.ncc.neon.models.queries.*;
+import com.ncc.neon.util.DateUtil;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
-
-import com.ncc.neon.models.queries.AggregateByFieldClause;
-import com.ncc.neon.models.queries.AggregateByGroupCountClause;
-import com.ncc.neon.models.queries.AggregateByTotalCountClause;
-import com.ncc.neon.models.queries.AndWhereClause;
-import com.ncc.neon.models.queries.FieldClause;
-import com.ncc.neon.models.queries.FieldsWhereClause;
-import com.ncc.neon.models.queries.GroupByFieldClause;
-import com.ncc.neon.models.queries.GroupByOperationClause;
-import com.ncc.neon.models.queries.JoinClause;
-import com.ncc.neon.models.queries.LimitClause;
-import com.ncc.neon.models.queries.MutateQuery;
-import com.ncc.neon.models.queries.OffsetClause;
-import com.ncc.neon.models.queries.OrWhereClause;
-import com.ncc.neon.models.queries.Query;
-import com.ncc.neon.models.queries.SelectClause;
-import com.ncc.neon.models.queries.SingularWhereClause;
-import com.ncc.neon.models.queries.OrderByFieldClause;
-import com.ncc.neon.models.queries.OrderByOperationClause;
-import com.ncc.neon.models.queries.Order;
-import com.ncc.neon.util.DateUtil;
 
 /**
  * Builds queries for the query adapters' unit tests.
@@ -779,7 +761,21 @@ public class QueryBuilder {
                 put("testNegativeDecimal", -0.5);
                 put("testTrue", true);
                 put("testFalse", false);
-            }});
+            }}, null);
+    }
+
+    protected MutateQuery buildMutationByFilterQuery() {
+        return new MutateQuery("testHost", "testType", "testDatabase", "testTable", "testIdField", "testId",
+                new LinkedHashMap<String, Object>(){{
+                    put("testString", "a");
+                    put("testZero", 0);
+                    put("testInteger", 1);
+                    put("testDecimal", 0.5);
+                    put("testNegativeInteger", -1);
+                    put("testNegativeDecimal", -0.5);
+                    put("testTrue", true);
+                    put("testFalse", false);
+                }}, SingularWhereClause.fromString(new FieldClause("testDatabase", "testTable", "testFilterField1"), "=", "testFilterValue1"));
     }
 
     protected MutateQuery buildArrayAndObjectMutationByIdQuery() {
@@ -805,6 +801,6 @@ public class QueryBuilder {
                         add(5);
                     }});
                 }});
-            }});
+            }}, SingularWhereClause.fromString(new FieldClause("testDatabase", "testTable", "testFilterField1"), "=", "testFilterValue1"));
     }
 }

--- a/common/src/main/java/com/ncc/neon/models/queries/MutateQuery.java
+++ b/common/src/main/java/com/ncc/neon/models/queries/MutateQuery.java
@@ -1,9 +1,9 @@
 package com.ncc.neon.models.queries;
 
-import java.util.Map;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
+
+import java.util.Map;
 
 @AllArgsConstructor
 @Data
@@ -15,4 +15,5 @@ public class MutateQuery {
     String idFieldName;
     String dataId;
     Map<String, Object> fieldsWithValues;
+    WhereClause whereClause;
 }

--- a/esadapter/src/main/java/com/ncc/neon/adapters/es/ElasticsearchAdapter.java
+++ b/esadapter/src/main/java/com/ncc/neon/adapters/es/ElasticsearchAdapter.java
@@ -36,6 +36,8 @@ import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
@@ -410,20 +412,42 @@ public class ElasticsearchAdapter extends QueryAdapter {
 
     @Override
     public Mono<ActionResult> deleteData(MutateQuery mutateQuery) {
-        DeleteRequest deleteRequest = ElasticsearchQueryConverter.convertMutationDeleteQuery(mutateQuery);
-        return Mono.create(sink -> {
-            client.deleteAsync(deleteRequest, RequestOptions.DEFAULT, new ActionListener<DeleteResponse>() {
-                @Override
-                public void onResponse(DeleteResponse deleteResponse) {
-                    processResponse(sink, deleteResponse);
-                }
+        if (mutateQuery.getWhereClause() == null) {
+            DeleteRequest deleteRequest = ElasticsearchQueryConverter.convertMutationDeleteByIdQuery(mutateQuery);
 
-                @Override
-                public void onFailure(Exception e) {
-                    sink.error(e);
-                }
+            return Mono.create(sink -> {
+                client.deleteAsync(deleteRequest, RequestOptions.DEFAULT, new ActionListener<DeleteResponse>() {
+                    @Override
+                    public void onResponse(DeleteResponse deleteResponse) {
+                        processResponse(sink, deleteResponse);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        sink.error(e);
+                    }
+                });
             });
-        });
+        } else {
+            DeleteByQueryRequest deleteRequest = ElasticsearchQueryConverter.convertMutationDeleteByFilterQuery(mutateQuery);
+
+            return Mono.create(sink -> {
+                client.deleteByQueryAsync(deleteRequest, RequestOptions.DEFAULT, new ActionListener<BulkByScrollResponse>() {
+                    @Override
+                    public void onResponse(BulkByScrollResponse response) {
+                        String responseText = response.getDeleted() + " documents deleted.";
+                        List<String> documentErrors = response.getBulkFailures().isEmpty() ? new ArrayList<String>() : response.getBulkFailures().stream().map(failure -> failure.toString()).collect(Collectors.toList());
+                        sink.success(new ActionResult(responseText, documentErrors));
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        sink.error(e);
+                    }
+                });
+            });
+        }
+
     }
 
     private void processResponse(MonoSink<ActionResult> sink, DocWriteResponse response) {

--- a/esadapter/src/main/java/com/ncc/neon/adapters/es/ElasticsearchQueryConverter.java
+++ b/esadapter/src/main/java/com/ncc/neon/adapters/es/ElasticsearchQueryConverter.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.*;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.BucketOrder;
@@ -132,7 +133,7 @@ public class ElasticsearchQueryConverter {
      * this case, a BoolQueryBuilder that combines all the subsidiary QueryBuilder
      * objects
      */
-    private static QueryBuilder convertWhereClauses(SelectClause selectClause, List<WhereClause> whereClauses) {
+    static QueryBuilder convertWhereClauses(SelectClause selectClause, List<WhereClause> whereClauses) {
         BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
 
         // Build the elasticsearch filters for the where clauses
@@ -430,7 +431,17 @@ public class ElasticsearchQueryConverter {
                 .source(mutateQuery.getFieldsWithValues());
     }
 
-    public static DeleteRequest convertMutationDeleteQuery(MutateQuery mutateQuery) {
+    public static DeleteRequest convertMutationDeleteByIdQuery(MutateQuery mutateQuery) {
         return new DeleteRequest(mutateQuery.getDatabaseName(), mutateQuery.getTableName(), mutateQuery.getDataId());
+
+    }
+
+    public static DeleteByQueryRequest convertMutationDeleteByFilterQuery(MutateQuery mutateQuery) {
+        SelectClause selectClause = new SelectClause(mutateQuery.getDatabaseName(), mutateQuery.getTableName());
+        QueryBuilder queryBuilder = convertWhereClauses(selectClause, List.of(mutateQuery.getWhereClause()));
+        DeleteByQueryRequest request = new DeleteByQueryRequest();
+        request.setQuery(queryBuilder);
+        request.getSearchRequest().indices("_all");
+        return request;
     }
 }

--- a/server/src/main/java/com/ncc/neon/controllers/DeleteController.java
+++ b/server/src/main/java/com/ncc/neon/controllers/DeleteController.java
@@ -83,7 +83,7 @@ public class DeleteController {
         }
 
         if (invalidInput.size() > 0) {
-            return ResponseEntity.badRequest().body(Mono.just(new ActionResult("Mutation by ID Query Missing " +
+            return ResponseEntity.badRequest().body(Mono.just(new ActionResult("Deletion by filter Query Missing " +
                     String.join(", ", invalidInput))));
         }
 

--- a/server/src/main/java/com/ncc/neon/controllers/InsertController.java
+++ b/server/src/main/java/com/ncc/neon/controllers/InsertController.java
@@ -1,30 +1,24 @@
 package com.ncc.neon.controllers;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 import com.ncc.neon.models.ConnectionInfo;
 import com.ncc.neon.models.DataNotification;
 import com.ncc.neon.models.queries.MutateQuery;
 import com.ncc.neon.models.results.ActionResult;
 import com.ncc.neon.services.DatasetService;
 import com.ncc.neon.services.QueryService;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Triple;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 @CrossOrigin(origins = "*")
 @RestController
@@ -57,7 +51,7 @@ public class InsertController {
                 .map(triple -> (String)triple.getLeft()).collect(Collectors.toList());
 
         if (invalidInput.size() > 0) {
-            return ResponseEntity.badRequest().body(Mono.just(new ActionResult("Mutation by ID Query Missing " +
+            return ResponseEntity.badRequest().body(Mono.just(new ActionResult("Insertion by ID Query Missing " +
                     String.join(", ", invalidInput))));
         }
 

--- a/server/src/test/java/com/ncc/neon/controllers/DeleteControllerTests.java
+++ b/server/src/test/java/com/ncc/neon/controllers/DeleteControllerTests.java
@@ -40,7 +40,7 @@ public class DeleteControllerTests {
     public void testDeleteWithInvalidInput() {
         MutateQuery mutateQuery = new MutateQuery("", "", "", "", "", "", new LinkedHashMap<String, Object>(), null);
         webTestClient.post()
-                .uri("/deleteservice/delete")
+                .uri("/deleteservice/byid")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .body(Mono.just(mutateQuery), MutateQuery.class)
                 .exchange()

--- a/server/src/test/java/com/ncc/neon/controllers/InsertControllerTests.java
+++ b/server/src/test/java/com/ncc/neon/controllers/InsertControllerTests.java
@@ -36,7 +36,7 @@ public class InsertControllerTests {
 
     @Test
     public void testInsertWithInvalidInput() {
-        MutateQuery mutateQuery = new MutateQuery("", "", "", "", "", "", new LinkedHashMap<String, Object>());
+        MutateQuery mutateQuery = new MutateQuery("", "", "", "", "", "", new LinkedHashMap<String, Object>(), null);
         webTestClient.post()
                 .uri("/insertservice/insert")
 				.contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -51,7 +51,7 @@ public class InsertControllerTests {
             "testId", new LinkedHashMap<String, Object>(){{
                 put("testStringField", "testStringValue");
             }}
-        );
+        , null);
 
         ActionResult mutateResult = new ActionResult("1 rows updated in testDatabase.testTable");
 

--- a/server/src/test/java/com/ncc/neon/controllers/MutateControllerTests.java
+++ b/server/src/test/java/com/ncc/neon/controllers/MutateControllerTests.java
@@ -1,17 +1,10 @@
 package com.ncc.neon.controllers;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-
 import com.ncc.neon.NeonServerApplication;
 import com.ncc.neon.models.ConnectionInfo;
 import com.ncc.neon.models.queries.MutateQuery;
 import com.ncc.neon.models.results.ActionResult;
 import com.ncc.neon.services.QueryService;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,8 +15,12 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
-
 import reactor.core.publisher.Mono;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = NeonServerApplication.class)
@@ -39,7 +36,7 @@ public class MutateControllerTests {
 
     @Test
     public void testMutateWithInvalidInput() {
-        MutateQuery mutateQuery = new MutateQuery("", "", "", "", "", "", new LinkedHashMap<String, Object>());
+        MutateQuery mutateQuery = new MutateQuery("", "", "", "", "", "", new LinkedHashMap<String, Object>(), null);
         webTestClient.post()
                 .uri("/mutateservice/byid")
 				.contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -53,7 +50,7 @@ public class MutateControllerTests {
         MutateQuery mutateQuery = new MutateQuery("testHost", "testType", "testDatabase", "testTable", "testIdField",
             "testId", new LinkedHashMap<String, Object>(){{
                 put("testStringField", "testStringValue");
-            }}
+            }}, null
         );
 
         ActionResult mutateResult = new ActionResult("One record failed to import");

--- a/server/src/test/java/com/ncc/neon/models/queries/MutateQueryJsonTest.java
+++ b/server/src/test/java/com/ncc/neon/models/queries/MutateQueryJsonTest.java
@@ -1,12 +1,6 @@
 package com.ncc.neon.models.queries;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-
 import com.ncc.neon.NeonServerApplication;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +8,11 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = NeonServerApplication.class)
@@ -64,8 +63,8 @@ public class MutateQueryJsonTest {
                         add(5);
                     }});
                 }});
-            }}
-        );
+            }},
+        null);
     }
 
 }

--- a/sqladapter/src/main/java/com/ncc/neon/adapters/sql/SqlAdapter.java
+++ b/sqladapter/src/main/java/com/ncc/neon/adapters/sql/SqlAdapter.java
@@ -177,8 +177,7 @@ public class SqlAdapter extends QueryAdapter {
         DatabaseClient database = DatabaseClient.create(this.pool);
         return database.execute(SqlQueryConverter.convertMutationQueryIntoDeleteQuery(mutateQuery)).fetch().rowsUpdated()
                 .map(rowCount -> new ActionResult(rowCount + " rows deleted in " + mutateQuery.getDatabaseName() + "." +
-                        mutateQuery.getTableName() + " with " + mutateQuery.getIdFieldName() + " = " +
-                        mutateQuery.getDataId(), new ArrayList<String>()));
+                        mutateQuery.getTableName(), new ArrayList<String>()));
     }
 
     private FieldType retrieveFieldType(String type) {

--- a/sqladapter/src/test/java/com/ncc/neon/adapters/sql/MySqlQueryConverterTest.java
+++ b/sqladapter/src/test/java/com/ncc/neon/adapters/sql/MySqlQueryConverterTest.java
@@ -732,9 +732,9 @@ public class MySqlQueryConverterTest extends QueryBuilder {
     public void convertInsertQueryTest() {
         MutateQuery mutateQuery = buildMutationByIdQuery();
         String actual = SqlQueryConverter.convertMutationIntoInsertQuery(mutateQuery);
-        String expected = "INSERT INTO testDatabase.testTable (testString, testZero, testInteger, testDecimal, " +
-                "testNegativeInteger, testNegativeDecimal, testTrue, testFalse) VALUES ('a', 0, 1, 0.5, -1, -0.5, " +
-                "true, false)";
+        String expected = "INSERT INTO testDatabase.testTable (id, testString, testZero, testInteger, testDecimal, " +
+                "testNegativeInteger, testNegativeDecimal, testTrue, testFalse) VALUES ('testId', 'a', 0, 1, 0.5, " +
+                "-1, -0.5, true, false)";
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -742,18 +742,28 @@ public class MySqlQueryConverterTest extends QueryBuilder {
     public void convertArrayAndObjectInsertQueryTest() {
         MutateQuery mutateQuery = buildArrayAndObjectMutationByIdQuery();
         String actual = SqlQueryConverter.convertMutationIntoInsertQuery(mutateQuery);
-        String expected = "INSERT INTO testDatabase.testTable (testEmptyArray, testEmptyObject, testArray, " +
-                "testObject) VALUES ('[]', '{}', '[\"b\",2,true,{\"testArrayObjectString\":\"c\"," +
+        String expected = "INSERT INTO testDatabase.testTable (id, testEmptyArray, testEmptyObject, testArray, " +
+                "testObject) VALUES ('testId', '[]', '{}', '[\"b\",2,true,{\"testArrayObjectString\":\"c\"," +
                 "\"testArrayObjectInteger\":3}]', '{\"testObjectString\":\"d\",\"testObjectInteger\":4," +
                 "\"testObjectBoolean\":true,\"testObjectArray\":[\"e\",5]}')";
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
-    public void convertDeleteQueryTest() {
+    public void convertDeleteByIdQueryTest() {
         MutateQuery mutateQuery = buildMutationByIdQuery();
+        mutateQuery.setDatastoreType("mysql");
         String actual = SqlQueryConverter.convertMutationQueryIntoDeleteQuery(mutateQuery);
         String expected = "DELETE FROM testDatabase.testTable WHERE testIdField = 'testId'";
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void convertDeleteByFilterQueryTest() {
+        MutateQuery mutateQuery = buildMutationByFilterQuery();
+        mutateQuery.setDatastoreType("mysql");
+        String actual = SqlQueryConverter.convertMutationQueryIntoDeleteQuery(mutateQuery);
+        String expected = "DELETE FROM testDatabase.testTable WHERE testDatabase.testTable.testFilterField1 = 'testFilterValue1'";
         assertThat(actual).isEqualTo(expected);
     }
 }

--- a/sqladapter/src/test/java/com/ncc/neon/adapters/sql/PostgreSqlQueryConverterTest.java
+++ b/sqladapter/src/test/java/com/ncc/neon/adapters/sql/PostgreSqlQueryConverterTest.java
@@ -733,9 +733,9 @@ public class PostgreSqlQueryConverterTest extends QueryBuilder {
     public void convertInsertQueryTest() {
         MutateQuery mutateQuery = buildMutationByIdQuery();
         String actual = SqlQueryConverter.convertMutationIntoInsertQuery(mutateQuery);
-        String expected = "INSERT INTO testDatabase.testTable (testString, testZero, testInteger, testDecimal, " +
-                "testNegativeInteger, testNegativeDecimal, testTrue, testFalse) VALUES ('a', 0, 1, 0.5, -1, -0.5, " +
-                "true, false)";
+        String expected = "INSERT INTO testDatabase.testTable (id, testString, testZero, testInteger, testDecimal, " +
+                "testNegativeInteger, testNegativeDecimal, testTrue, testFalse) VALUES ('testId', 'a', 0, 1, 0.5, " +
+                "-1, -0.5, true, false)";
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -743,18 +743,28 @@ public class PostgreSqlQueryConverterTest extends QueryBuilder {
     public void convertArrayAndObjectInsertQueryTest() {
         MutateQuery mutateQuery = buildArrayAndObjectMutationByIdQuery();
         String actual = SqlQueryConverter.convertMutationIntoInsertQuery(mutateQuery);
-        String expected = "INSERT INTO testDatabase.testTable (testEmptyArray, testEmptyObject, testArray, " +
-                "testObject) VALUES ('[]', '{}', '[\"b\",2,true,{\"testArrayObjectString\":\"c\"," +
+        String expected = "INSERT INTO testDatabase.testTable (id, testEmptyArray, testEmptyObject, testArray, " +
+                "testObject) VALUES ('testId', '[]', '{}', '[\"b\",2,true,{\"testArrayObjectString\":\"c\"," +
                 "\"testArrayObjectInteger\":3}]', '{\"testObjectString\":\"d\",\"testObjectInteger\":4," +
                 "\"testObjectBoolean\":true,\"testObjectArray\":[\"e\",5]}')";
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
-    public void convertDeleteQueryTest() {
+    public void convertDeleteByIdQueryTest() {
         MutateQuery mutateQuery = buildMutationByIdQuery();
+        mutateQuery.setDatastoreType("postgresql");
         String actual = SqlQueryConverter.convertMutationQueryIntoDeleteQuery(mutateQuery);
         String expected = "DELETE FROM testDatabase.testTable WHERE testIdField = 'testId'";
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void convertDeleteByFilterQueryTest() {
+        MutateQuery mutateQuery = buildMutationByFilterQuery();
+        mutateQuery.setDatastoreType("postgresql");
+        String actual = SqlQueryConverter.convertMutationQueryIntoDeleteQuery(mutateQuery);
+        String expected = "DELETE FROM testDatabase.testTable WHERE testDatabase.testTable.testFilterField1 = 'testFilterValue1'";
         assertThat(actual).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
Separated out delete by Id and Filter in the REST endpoints. Both use the same underlying methods other than conversion.

Added tests for all three adapters (MySQL, PostgreSQL, ES). Fixed compatibility with the new whereClause in MutateQuery.

Here are test calls: 

ElasticSearch:
```
{
  "datastoreHost": "elastic:changeme@localhost",
  "datastoreType": "elasticsearch",
  "databaseName": "earthquakes",
  "tableName": "_doc",
  "idFieldName": "testIdField",
  "dataId": "testId",
  "whereClause": {
        "type": "where",
        "lhs": {
            "database": "earthquakes",
            "table": "_doc",
            "field": "mag"
        },
        "operator": "=",
        "rhs": 1.512345678
   }
}
```

SQL:
```
{
  "datastoreHost": "user:password@localhost/earthquakes",
  "datastoreType": "postgresql",
  "databaseName": "earthquakes",
  "tableName": "quakedata",
  "idFieldName": "id",
  "dataId": "testId",
  "whereClause": {
        "type": "where",
        "lhs": {
            "database": "earthquakes",
            "table": "quakedata",
            "field": "mag"
        },
        "operator": "=",
        "rhs": 1.512345678
   }
}
```

Checked deletion of data with PgAdmin and `http://localhost:9200/earthquakes/_search?q=mag:1.512345678&pretty`